### PR TITLE
Fix grammar - remove unnecessary word

### DIFF
--- a/site/static/app/templates/guides/learn-standardml/expressions-and-variables.jade
+++ b/site/static/app/templates/guides/learn-standardml/expressions-and-variables.jade
@@ -252,7 +252,7 @@ block body
                     p.
                         Variables in Standard ML are immutable. However not all values in
                         are immutable. <code>ref</code> cells are the simplest example of mutable
-                        values. Here are is a full example using <code>ref</code> cells:
+                        values. Here is a full example using <code>ref</code> cells:
                     pre
                         code.
                             let


### PR DESCRIPTION
The use of the word 'are' seems unnecessary.