### PR TITLE
Fix error in computing an expression using a ref

### DIFF
--- a/site/static/app/templates/guides/learn-standardml/expressions-and-variables.jade
+++ b/site/static/app/templates/guides/learn-standardml/expressions-and-variables.jade
@@ -264,7 +264,7 @@ block body
                                 c * (!a) + (!b)
                             end
                     p.
-                        The result of this expression is (1 + 3) * (3) + (1) = 15.
+                        The result of this expression is (1 + 3) * (3) + (3) = 15.
                         The <code>!</code> operator dereferences the ref cell to get its value.
                         The type of <code>a</code> and <code>b</code> is <code>ref int</code>.
                     p.


### PR DESCRIPTION
Perhaps, additionally, it might be useful to point out (to a newbie, especially) that since `a` and `b` reference the same `ref` cell, any update of the cell via `a` would result in `(!b)` dereferencing the updated value.